### PR TITLE
Fix test on Windows

### DIFF
--- a/src/test/kotlin/io/github/detekt/sarif4k/SarifSerializerTest.kt
+++ b/src/test/kotlin/io/github/detekt/sarif4k/SarifSerializerTest.kt
@@ -79,8 +79,8 @@ class SarifSerializerTest {
 
     @Test
     fun `serialize kotlin data class to json`() {
-        val actual = SarifSerializer.toJson(sarifSchema210)
-        val expected = File(SarifSerializerTest::class.java.getResource("/test.sarif.json").path).readText()
+        val actual = SarifSerializer.toJson(sarifSchema210).lines()
+        val expected = File(SarifSerializerTest::class.java.getResource("/test.sarif.json").path).readLines()
         assertEquals(expected, actual)
     }
 


### PR DESCRIPTION
Test `serialize kotlin data class to json` fails on Windows. The reason is in pretty print in JSON and end of line which is platform dependent. 
Test can be fixed by splitting String to lines() and reading a lines from resource

_Originally posted by @nulls in https://github.com/detekt/sarif4k/pull/6#discussion_r1021494080_