### PR TITLE
Bump CI step versions (checkout, cache, java)

### DIFF
--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -19,10 +19,10 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache Gradle Files
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches/

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -7,10 +7,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache Gradle Files
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches/

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -19,9 +19,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Set up Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'zulu'
+          java-version: 8
 
       - name: Build
         run: ./gradlew build


### PR DESCRIPTION
## Motivation
![image](https://user-images.githubusercontent.com/2906988/202847649-b1790582-98df-4b5b-9db2-63fdb799c631.png)

After bumping checkout and cache:
![image](https://user-images.githubusercontent.com/2906988/202847837-19b540eb-3ceb-4e9a-ac7b-b63bdacf0003.png)

## Upgrades
 - [x] cache https://github.com/actions/cache/releases/tag/v3.0.0  
       (Node 16, which affects GitHub Enterprise users, hence major)
 - [x] checkout https://github.com/actions/checkout/releases/tag/v3.0.0  
       (Node 16, which affects GitHub Enterprise users, hence major)
 - [x] java v2 https://github.com/actions/setup-java/releases/tag/v2.0.0
       (Configuration changes -> [migration guide](https://github.com/actions/setup-java/blob/main/docs/switching-to-v2.md))
 - [x] java v3 https://github.com/actions/setup-java/releases/tag/v3.0.0  
       (Node 16, which affects GitHub Enterprise users, hence major)