### PR TITLE
Cache CVE database & upload reports

### DIFF
--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -30,6 +30,19 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+
+      - name: Cache CVE database Files
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3
+        with:
+          path: |
+            ~/.gradle/dependency-check-data/
+          # Use the hash of the gradle files as the key for now,
+          # which contains the `org.owasp.dependencycheck` plugin version.
+          # The database might depend on other things as well, like date, but this is good enough.
+          key: dependency-check-${{ hashFiles('build.gradle.kts') }}
+          restore-keys: |
+            dependency-check-
+
       - name: Run Gradle tasks
         run: ./gradlew build 
 

--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -46,5 +46,21 @@ jobs:
       - name: Run Gradle tasks
         run: ./gradlew build 
 
+      - name: Upload 'Test Report' artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
+        if: success() || failure()
+        with:
+          name: Test Report
+          path: |
+            build/reports/tests/allTests/
+
       - name: Dependency Check
         run: ./gradlew dependencyCheckAnalyze
+
+      - name: Upload 'Dependency Check Report' artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
+        if: success() || failure()
+        with:
+          name: Dependency Check Report
+          path: |
+            build/reports/dependency-check-report.html


### PR DESCRIPTION
fixes #24

Testing: https://github.com/detekt/sarif4k/actions/runs/4242662085

Luckily ubuntu job ran first, fully to completion: https://github.com/detekt/sarif4k/actions/runs/4242662085/jobs/7374450595
we can see here that the cache was stored
![image](https://user-images.githubusercontent.com/2906988/220620351-5f252174-ba68-41e6-bab8-9e3d302b7527.png)

Then the mac job ran:
https://github.com/detekt/sarif4k/actions/runs/4242662085/jobs/7374450387
and picked up the stored cache
![image](https://user-images.githubusercontent.com/2906988/220620872-858d536c-5502-4edd-9189-94909a51f9f3.png)

This should mean that the download won't be flaky, most of the files will exist so there's less to download from NVD.

This also decreased the dependency check runtime from 4.5 minutes to 22 seconds.