### PR TITLE
[M1] Adding macosArm64() target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
     linuxX64()
     mingwX64()
     macosX64()
+    macosArm64()
 
     sourceSets {
         all {


### PR DESCRIPTION
### What's done:

- It's time to add macosArm64() target for Native