### PR TITLE
 Add default workflow for Gradle's dependency-submission action

### DIFF
--- a/.github/workflows/gradle-dependency-submission.yaml
+++ b/.github/workflows/gradle-dependency-submission.yaml
@@ -1,0 +1,18 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@ec92e829475ac0c2315ea8f9eced72db85bb337a # v3


### PR DESCRIPTION
https://github.com/gradle/actions/blob/v3.0.0/dependency-submission/README.md#general-usage

Also from the README:

> The gradle/actions/dependency-submission action provides the simplest (and recommended) way to generate a dependency graph for your project. This action will attempt to detect all dependencies used by your build without building and testing the project itself.
>
> The dependency graph snapshot is generated via integration with the [GitHub Dependency Graph Gradle Plugin](https://plugins.gradle.org/plugin/org.gradle.github-dependency-graph-gradle-plugin), and submitted to your repository via the [GitHub Dependency Submission API](https://docs.github.com/en/rest/dependency-graph/dependency-submission). The generated snapshot files can be submitted in the same job, or saved for submission in a subsequent job.
>
> The generated dependency graph includes all of the dependencies in your build, and is used by GitHub to generate [Dependabot Alerts](https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts) for vulnerable dependencies, as well as to populate the [Dependency Graph insights view](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/exploring-the-dependencies-of-a-repository#viewing-the-dependency-graph).

(This is basically a cherry-pick from this PR: https://github.com/detekt/detekt/pull/6933)