### PR TITLE
Allow running dependencies manually

### DIFF
--- a/.github/workflows/gradle-dependency-submission.yaml
+++ b/.github/workflows/gradle-dependency-submission.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: 
 
 permissions:
   contents: write


### PR DESCRIPTION
This helps for example running it on PRs without merging first. But not always, only when one of us wants to.

There'll be button here:
https://github.com/detekt/sarif4k/actions/workflows/gradle-dependency-submission.yaml