### PR TITLE
Turn on Gradle wrapper validation

### DIFF
--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: "Setup gradle"
         uses: gradle/actions/setup-gradle@6cec5d49d4d6d4bb982fbed7047db31ea6d38f11 # v3
+        with:
+          validate-wrappers: true
 
       - name: "Run Gradle tasks"
         run: ./gradlew build


### PR DESCRIPTION
This is a new feature released yesterday: https://github.com/gradle/actions/releases/tag/v3.3.0

I was surprised this is not enabled yet in the repo through the separate action. Now that it's part of it, it's even simpler to enable.