### PR TITLE
Update secrets to match detekt/detekt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,5 +33,5 @@ jobs:
       - name: "Publish package"
         run: ./gradlew publishToSonatype
         env:
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.MAVEN_CENTRAL_USER }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.MAVEN_CENTRAL_PW }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}


### PR DESCRIPTION
I've removed the `MAVEN_CENTRAL_*` secrets as they were effectively duplicates from the other secrets we have at the org level for detekt/detekt

Fixes #128