### PR TITLE
Update schema attribute for SARIF 2.1.0 Errata 01

### DIFF
--- a/src/jvmTest/kotlin/io/github/detekt/sarif4k/SarifSerializerTest.kt
+++ b/src/jvmTest/kotlin/io/github/detekt/sarif4k/SarifSerializerTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertEquals
 class SarifSerializerTest {
 
     private val sarifSchema210 = SarifSchema210(
-        schema = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+        schema = "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
         version = Version.The210,
         runs = listOf(
             Run(

--- a/src/jvmTest/resources/input_1.sarif.json
+++ b/src/jvmTest/resources/input_1.sarif.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/jvmTest/resources/input_2.sarif.json
+++ b/src/jvmTest/resources/input_2.sarif.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/jvmTest/resources/input_2_different_tool.sarif.json
+++ b/src/jvmTest/resources/input_2_different_tool.sarif.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+    "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
     "version": "2.1.0",
     "runs": [
         {

--- a/src/jvmTest/resources/output.sarif.json
+++ b/src/jvmTest/resources/output.sarif.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+    "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
     "version": "2.1.0",
     "runs": [
         {

--- a/src/jvmTest/resources/output_different_tool.sarif.json
+++ b/src/jvmTest/resources/output_different_tool.sarif.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+    "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
     "version": "2.1.0",
     "runs": [
         {

--- a/src/jvmTest/resources/test.sarif.json
+++ b/src/jvmTest/resources/test.sarif.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
   "version": "2.1.0",
   "runs": [
     {


### PR DESCRIPTION
The current URL returns a 404. SARIF 2.10 Errata 01 says the SARIF schema is available at this new URL. Reference: https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790731