### PR TITLE
#230: Automate releases from GitHub tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,17 +4,20 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '*.*.*'
+      - 'v*.*.*'
 
 jobs:
-  publish:
-    name: "Publish to Sonatype"
+  publish-snapshot:
+    name: "Publish snapshot to Sonatype"
+    if: github.repository == 'detekt/sarif4k' && github.ref_type == 'branch'
     runs-on: macos-latest
 
     permissions:
       contents: read
 
     steps:
-
       - name: "Checkout sources"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -30,8 +33,57 @@ jobs:
       - name: "Build"
         run: ./gradlew build
 
-      - name: "Publish package"
+      - name: "Publish snapshot"
         run: ./gradlew publishToSonatype
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
+
+  publish-release:
+    name: "Publish release to Sonatype"
+    if: github.repository == 'detekt/sarif4k' && github.ref_type == 'tag'
+    runs-on: macos-latest
+    environment:
+      name: release
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: "Checkout sources"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: "Set up Java"
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: 'zulu'
+          java-version-file: '.java-version'
+
+      - name: "Setup gradle"
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
+
+      - name: "Resolve release version"
+        run: echo "RELEASE_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      - name: "Validate release version"
+        run: |
+          if [[ "$RELEASE_VERSION" == *-SNAPSHOT ]]; then
+            echo "Release tags must resolve to a non-SNAPSHOT version"
+            exit 1
+          fi
+
+      - name: "Build"
+        run: ./gradlew build -PVERSION="$RELEASE_VERSION"
+
+      - name: "Publish release"
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -PVERSION="$RELEASE_VERSION"
+        env:
+          ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
+
+      - name: "Create GitHub release"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --generate-notes --title "Version $RELEASE_VERSION"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,9 +11,9 @@
    - publish the artifacts to Sonatype and close/release the staging repository using the repository secrets
    - create the GitHub release entry for the tag
 5. Verify the version is published.
-   - https://oss.sonatype.org/content/groups/public/io/github/detekt/sarif4k/sarif4k
+   - https://central.sonatype.com/artifact/io.github.detekt.sarif4k/sarif4k
    - https://repo.maven.apache.org/maven2/io/github/detekt/sarif4k/sarif4k/
    - https://repo1.maven.org/maven2/io/github/detekt/sarif4k/sarif4k/
-6. Visit [Sonatype Nexus](https://oss.sonatype.org/) to debug if anything goes wrong.
+6. Visit [Sonatype Central Portal](https://central.sonatype.com/) to debug if anything goes wrong.
 
 Pushes to `main` continue to publish the snapshot version via the same [Release workflow](.github/workflows/release.yml).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,20 +1,19 @@
 # Releasing
 
-- Update 
-  - the version in `gradle.properties` to a non-SNAPSHOT version. 
-  - `README.md` with the new version.
-  - `git commit -am "Prepare for release X.Y.Z"` (where X.Y.Z is the new version)
-  - `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)
-- Publish the version
-  - Run`./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository` locally
-  - Create a new release in the releases tab on GitHub
-  - Verify the version is published
-    - https://oss.sonatype.org/content/groups/public/io/github/detekt/sarif4k/sarif4k
-    - https://repo.maven.apache.org/maven2/io/github/detekt/sarif4k/sarif4k/
-    - https://repo1.maven.org/maven2/io/github/detekt/sarif4k/sarif4k/
-  - Visit [Sonatype Nexus](https://oss.sonatype.org/) to debug if there is anything wrong.
-- Update 
-  - `gradle.properties` to the next SNAPSHOT version (X.Y.Z)
-  - `git commit -am "Prepare next development version."`
-  - `git push && git push --tags`
-- Wait for the [publish-snapshot.yml](.github/workflows/publish-snapshot.yml) action to complete.
+1. Keep `gradle.properties` on the next `-SNAPSHOT` version on `main`.
+2. Create and push an annotated release tag from the commit you want to publish.
+   - Example: `git tag -a 0.7.0 -m "Version 0.7.0"`
+   - Example: `git push origin 0.7.0`
+3. Wait for the [Release workflow](.github/workflows/release.yml) to start, then approve the `release` environment deployment.
+   - Configure required reviewers for the `release` environment in GitHub settings to enforce the second-maintainer approval requested in issue #230.
+4. The workflow will:
+   - build sarif4k with the tag version
+   - publish the artifacts to Sonatype and close/release the staging repository using the repository secrets
+   - create the GitHub release entry for the tag
+5. Verify the version is published.
+   - https://oss.sonatype.org/content/groups/public/io/github/detekt/sarif4k/sarif4k
+   - https://repo.maven.apache.org/maven2/io/github/detekt/sarif4k/sarif4k/
+   - https://repo1.maven.org/maven2/io/github/detekt/sarif4k/sarif4k/
+6. Visit [Sonatype Nexus](https://oss.sonatype.org/) to debug if anything goes wrong.
+
+Pushes to `main` continue to publish the snapshot version via the same [Release workflow](.github/workflows/release.yml).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.publish.maven.tasks.PublishToMavenLocal
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
@@ -106,19 +107,35 @@ publishing {
     }
 }
 
-if (findProperty("signing.keyId") != null) {
-    signing {
+val inMemorySigningKey = providers.gradleProperty("SIGNING_KEY").orNull
+val inMemorySigningPassword = providers.gradleProperty("SIGNING_PWD").orNull
+val hasInMemorySigning = !inMemorySigningKey.isNullOrBlank() && !inMemorySigningPassword.isNullOrBlank()
+val hasKeyringSigning = findProperty("signing.keyId") != null
+
+signing {
+    when {
+        hasInMemorySigning -> {
+            useInMemoryPgpKeys(inMemorySigningKey, inMemorySigningPassword)
+        }
+
+        hasKeyringSigning -> Unit
+
+        else -> logger.lifecycle("Signing disabled as no PGP key was configured")
+    }
+
+    if (hasInMemorySigning || hasKeyringSigning) {
         publishing.publications.withType(MavenPublication::class).configureEach {
             sign(this)
         }
     }
-} else {
-    logger.lifecycle("Signing Disabled as the PGP key was not found")
 }
 
 // https://github.com/gradle-nexus/publish-plugin/issues/208
 val signingTasks: TaskCollection<Sign> = tasks.withType<Sign>()
 tasks.withType<PublishToMavenRepository>().configureEach {
+    mustRunAfter(signingTasks)
+}
+tasks.withType<PublishToMavenLocal>().configureEach {
     mustRunAfter(signingTasks)
 }
 


### PR DESCRIPTION
## Summary
- trigger automated releases from semver tags while keeping snapshot publishing on pushes to main
- publish tag builds through the protected GitHub Actions release path using repository secrets and a required release environment approval
- document the new tag-driven release process and add CI-friendly in-memory signing support for release publishing

Closes #230

## Validation
- ./gradlew build
- ./gradlew properties -q -PVERSION=0.7.0 | rg '^version:'
- ./gradlew publishToMavenLocal -PVERSION=0.7.0 -Dmaven.repo.local=<temp> with a temporary in-memory PGP key
