### PR TITLE
Pin kotlinx-io and kotlinx-serialization to their last Kotlin 2.2 releases

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,9 +46,14 @@ kotlin {
         }
         val commonMain by getting {
             dependencies {
-                api("org.jetbrains.kotlinx:kotlinx-io-core:0.9.0")
-                api("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-io:1.11.0")
+                // These api-exposed dependencies are intentionally held back to their
+                // last Kotlin 2.2-built releases. Newer versions (kotlinx-io 0.9.x,
+                // kotlinx-serialization 1.10.x+) are compiled at language version 2.3,
+                // whose metadata cannot be read by consumers still on Kotlin 2.1 — e.g.
+                // the Detekt Gradle Plugin's report-merge task. See detekt/detekt#9330.
+                api("org.jetbrains.kotlinx:kotlinx-io-core:0.8.2")
+                api("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-io:1.9.0")
             }
         }
         val commonTest by getting {

--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,22 @@
   "extends": [
     "config:recommended",
     "helpers:pinGitHubActionDigests"
+  ],
+  "packageRules": [
+    {
+      "description": "Hold kotlinx-io at its last Kotlin 2.2-built release. 0.9.x is compiled at language version 2.3, whose metadata cannot be read by consumers still on Kotlin 2.1 (e.g. the Detekt Gradle Plugin). See detekt/detekt#9330.",
+      "matchPackageNames": [
+        "org.jetbrains.kotlinx:kotlinx-io-core"
+      ],
+      "allowedVersions": "<0.9.0"
+    },
+    {
+      "description": "Hold kotlinx-serialization at its last Kotlin 2.2-built release. 1.10.x+ is compiled at language version 2.3, whose metadata cannot be read by consumers still on Kotlin 2.1 (e.g. the Detekt Gradle Plugin). See detekt/detekt#9330.",
+      "matchPackageNames": [
+        "org.jetbrains.kotlinx:kotlinx-serialization-json",
+        "org.jetbrains.kotlinx:kotlinx-serialization-json-io"
+      ],
+      "allowedVersions": "<1.10.0"
+    }
   ]
 }


### PR DESCRIPTION
## Problem

sarif4k 0.7.0 can't be consumed by projects still building with Kotlin 2.1.
The most concrete case is detekt itself: its Gradle plugin performs SARIF
report merging via sarif4k, but the Detekt Gradle Plugin is compiled against
`kotlin-gradle-plugin-api` **2.1.0** (its supported floor). Kotlin 2.1 refuses
to read dependency metadata compiled at language version 2.3, so the plugin
fails to compile against sarif4k 0.7.0. This currently blocks detekt from
upgrading — see detekt/detekt#9330 and detekt/detekt#9247.

## Root cause

sarif4k's own classes are already emitted at metadata version 2.2 (the build
pins `languageVersion`/`apiVersion`/`coreLibrariesVersion` to 2.2), so they're
fine. The blocker is the **api-exposed transitive dependencies**, which were
compiled at language version 2.3:

- `kotlinx-io-core` 0.9.x
- `kotlinx-serialization-json` / `-json-io` 1.10.x+

Because these are on the public API surface, consumers must read their metadata
too — and Kotlin 2.1 can't.

## Fix

Hold these dependencies at their last Kotlin 2.2-built releases, so the entire
published API surface stays at metadata version 2.2 (readable by Kotlin 2.1):

| Dependency | Before | After |
| --- | --- | --- |
| `kotlinx-io-core` | 0.9.0 | **0.8.2** |
| `kotlinx-serialization-json` | 1.11.0 | **1.9.0** |
| `kotlinx-serialization-json-io` | 1.11.0 | **1.9.0** |

Also adds Renovate `packageRules` (`allowedVersions`) so these aren't
auto-bumped back past the 2.2 line and silently reintroduce the incompatibility.

## Verification

- `./gradlew clean jvmTest checkKotlinAbi` — green; **public ABI unchanged**
  (no `api/*.api` regeneration needed), streaming serializer unaffected by the
  older kotlinx-io.
- Metadata check: sarif4k's own classes and all three downgraded deps now emit
  `@Metadata(mv=[2,2,0])`.
- Published locally and compiled **detekt's Gradle plugin** against it with
  `org.gradle.kotlin.dsl.skipMetadataVersionCheck=false` (metadata checking on):
  `:detekt-gradle-plugin:compileKotlin` and `:test` both pass, resolving
  sarif4k 0.7.0-SNAPSHOT → kotlinx-io 0.8.2 / serialization 1.9.0.
