### PR TITLE
Create libs.catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 plugins {
-    kotlin("multiplatform") version "2.3.20"
-    kotlin("plugin.serialization") version "2.3.20"
-    id("org.jetbrains.dokka") version "2.2.0"
-    id("com.vanniktech.maven.publish") version "0.37.0"
-    id("com.gradleup.tapmoc") version "0.4.2"
+    alias(libs.plugins.kotlin)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.dokka)
+    alias(libs.plugins.vanniktechPublish)
+    alias(libs.plugins.tapmoc)
 }
 
 group = property("GROUP")!!
@@ -35,9 +35,9 @@ kotlin {
         }
         getByName("commonMain") {
             dependencies {
-                api("org.jetbrains.kotlinx:kotlinx-io-core:0.8.2")
-                api("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-io:1.9.0")
+                api(libs.kotlinx.io)
+                api(libs.kotlinx.serialization.json)
+                api(libs.kotlinx.serialization.json.io)
             }
         }
         getByName("commonTest") {
@@ -49,8 +49,8 @@ kotlin {
             dependencies {
                 implementation(kotlin("stdlib"))
                 implementation(kotlin("test"))
-                runtimeOnly("org.junit.platform:junit-platform-launcher")
-                implementation("org.junit.jupiter:junit-jupiter:5.14.4")
+                runtimeOnly(libs.junit.launcher)
+                implementation(libs.junit)
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,17 @@
+[versions]
+kotlin-gradle-plugin = "2.3.20"
+kotlinx-serialization = "1.9.0"
+
+[libraries]
+kotlinx-io = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version = "0.8.2" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+kotlinx-serialization-json-io = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json-io", version.ref = "kotlinx-serialization" }
+junit = { module = "org.junit.jupiter:junit-jupiter", version = "5.14.4" }
+junit-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+
+[plugins]
+kotlin = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin-gradle-plugin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin-gradle-plugin" }
+dokka = { id = "org.jetbrains.dokka", version = "2.2.0" }
+vanniktechPublish = { id = "com.vanniktech.maven.publish", version = "0.37.0" }
+tapmoc = { id = "com.gradleup.tapmoc", version = "0.4.2" }


### PR DESCRIPTION
Right now renovate generates these 4 PRs when they should be only 2 because some of those we want to update them together.

Using the catalog wiht `version.ref` we can force renovate to update them at the same time.

<img width="1036" height="312" alt="Captura de pantalla 2026-08-24 a las 10 55 40" src="https://github.com/user-attachments/assets/53ce6fe1-0811-4048-bc91-119c45186a30" />
